### PR TITLE
fix: Handle missing video content in admin courses learning resources

### DIFF
--- a/templates/users/administrator/course/learning_resource/video_detail.html
+++ b/templates/users/administrator/course/learning_resource/video_detail.html
@@ -2,35 +2,42 @@
 {% load i18n %}
 
 {% block resource_specific_content %}
-<div class="aspect-w-16 aspect-h-9 mb-4">
-    <video controls class="rounded-lg shadow-lg w-full" preload="metadata">
-        <source src="{{ resource.content.url }}" type="video/mp4">
-        <source src="{{ resource.content.url }}" type="video/webm">
-        <source src="{{ resource.content.url }}" type="video/ogg">
-        {% trans "Your browser does not support the video tag." %}
-    </video>
-</div>
+{% if resource.content %}
+    <div class="aspect-w-16 aspect-h-9 mb-4">
+        <video controls class="rounded-lg shadow-lg w-full" preload="metadata">
+            <source src="{{ resource.content.url }}" type="video/mp4">
+            <source src="{{ resource.content.url }}" type="video/webm">
+            <source src="{{ resource.content.url }}" type="video/ogg">
+            {% trans "Your browser does not support the video tag." %}
+        </video>
+    </div>
 
-<div class="mt-4">
-    <h3 class="text-lg font-semibold mb-2">{% trans "Download Options" %}</h3>
-    <a href="{{ resource.content.url }}" download class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded inline-flex items-center">
-        <i class="fas fa-download mr-2"></i>{% trans "Download Video" %}
-    </a>
-</div>
+    <div class="mt-4">
+        <h3 class="text-lg font-semibold mb-2">{% trans "Download Options" %}</h3>
+        <a href="{{ resource.content.url }}" download class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded inline-flex items-center">
+            <i class="fas fa-download mr-2"></i>{% trans "Download Video" %}
+        </a>
+    </div>
 
-<div class="mt-4">
-    <h3 class="text-lg font-semibold mb-2">{% trans "Video Information" %}</h3>
-    <p><strong>{% trans "File Name" %}:</strong> {{ resource.content.name }}</p>
-    <p><strong>{% trans "File Size" %}:</strong> {{ resource.content.size|filesizeformat }}</p>
-</div>
+    <div class="mt-4">
+        <h3 class="text-lg font-semibold mb-2">{% trans "Video Information" %}</h3>
+        <p><strong>{% trans "File Name" %}:</strong> {{ resource.content.name }}</p>
+        <p><strong>{% trans "File Size" %}:</strong> {{ resource.content.size|filesizeformat }}</p>
+    </div>
+{% else %}
+    <div class="bg-yellow-100 border-l-4 border-yellow-500 text-yellow-700 p-4 mb-4" role="alert">
+        <p class="font-bold">{% trans "No Video Content Available" %}</p>
+        <p>{% trans "There is currently no video content associated with this learning resource." %}</p>
+    </div>
+{% endif %}
 
 {% if resource.external_url %}
-<div class="mt-4">
-    <h3 class="text-lg font-semibold mb-2">{% trans "External Video Link" %}</h3>
-    <a href="{{ resource.external_url }}" target="_blank" class="bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded inline-flex items-center">
-        <i class="fas fa-external-link-alt mr-2"></i>{% trans "Open External Video" %}
-    </a>
-</div>
+    <div class="mt-4">
+        <h3 class="text-lg font-semibold mb-2">{% trans "External Video Link" %}</h3>
+        <a href="{{ resource.external_url }}" target="_blank" class="bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded inline-flex items-center">
+            <i class="fas fa-external-link-alt mr-2"></i>{% trans "Open External Video" %}
+        </a>
+    </div>
 {% endif %}
 
 <script>


### PR DESCRIPTION
- Add conditional rendering for video content in template
- Display warning message when no video content is available
- Maintain external URL link display regardless of content presence
- Improve user experience by providing clear feedback on resource status