### PR TITLE
feat: Add announcement detail page

### DIFF
--- a/templates/users/administrator/announcements/announcement_detail.html
+++ b/templates/users/administrator/announcements/announcement_detail.html
@@ -1,0 +1,49 @@
+{% extends '../_base.html' %}
+{% load static %}
+{% load i18n %}
+
+{% block title %}{% trans "Announcements - LMS Admin" %}{% endblock %}
+
+{% block extra_css %}
+{% endblock %}
+
+{% block content %}
+
+<div class="container mx-auto p-4">
+    <h1 class="text-2xl font-bold mb-4">{{ announcement.title }}</h1>
+    <div class="mb-4">
+        <span class="font-semibold">Priority:</span>
+        <span class="
+            {% if announcement.priority == 'LOW' %}
+                bg-green-100
+            {% elif announcement.priority == 'MEDIUM' %}
+                bg-yellow-100
+            {% elif announcement.priority == 'HIGH' %}
+                bg-orange-100
+            {% elif announcement.priority == 'URGENT' %}
+                bg-red-100
+            {% endif %}
+            px-2 py-1 rounded
+        ">
+            {{ announcement.priority }}
+        </span>
+    </div>
+    <div class="mb-4">
+        <span class="font-semibold">Published Date:</span> {{ announcement.published_date }}
+    </div>
+    <div class="mb-4">
+        <span class="font-semibold">Expiry Date:</span> {{ announcement.expiry_date }}
+    </div>
+    <div class="mb-4">
+        <span class="font-semibold">Created At:</span> {{ announcement.created_at }}
+    </div>
+    <div class="mb-4">
+        <span class="font-semibold">Updated At:</span> {{ announcement.updated_at }}
+    </div>
+    <div class="mb-4">
+        <span class="font-semibold">Content:</span> {{ announcement.content }}        
+    </div>
+    <a href="{% url 'administrator_announcement_list' %}" class="text-blue-500">Back to Announcements List</a>
+</div>
+
+{% endblock %}

--- a/templates/users/administrator/announcements/announcements.html
+++ b/templates/users/administrator/announcements/announcements.html
@@ -132,9 +132,11 @@
                     <td class="px-6 py-4">{{announcement.created_at}}</td>
                     <td class="px-6 py-4">{{announcement.updated_at}}</td>
                     <td class="px-6 py-4">
-                        <button class="text-blue-600 hover:text-blue-900" title="{% trans 'Edit Announcement' %}">
-                            <i class="fas fa-edit"></i>
-                        </button>
+                        <a href="{% url 'administrator_announcement_detail' announcement.pk %}" title="{% trans 'View Details' %}">
+                            <button class="text-green-600 hover:text-green-900 ml-3 rtl:mr-3 rtl:ml-0">
+                                <i class="fas fa-eye"></i>
+                            </button>
+                        </a>
                         <button class="text-green-600 hover:text-green-900 ml-3 rtl:mr-3 rtl:ml-0" title="{% trans 'View Statistics' %}">
                             <i class="fas fa-chart-bar"></i>
                         </button>

--- a/users/administrator_views.py
+++ b/users/administrator_views.py
@@ -1590,18 +1590,24 @@ class AdministratorNotificationListView(TemplateView):
 # ============================================================
 # ======================= Announcements Views ================
 # ============================================================
-class AdministratorAnnouncementListView(TemplateView):
+class AdministratorAnnouncementListView(LoginRequiredMixin, UserPassesTestMixin,TemplateView):
     template_name = 'users/administrator/announcements/announcements.html'
+
+    def test_func(self):
+        return self.request.user.groups.filter(name='administrator').exists()
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['announcements'] = Announcement.objects.all()
         return context
     
-class AdministratorAnnouncementCreateView(FormView):
+class AdministratorAnnouncementCreateView(LoginRequiredMixin, UserPassesTestMixin,FormView):
     form_class = AnnouncementForm
     template_name = 'users/administrator/announcements/announcement_create.html'
     success_url = reverse_lazy('administrator_announcement_list')
+
+    def test_func(self):
+        return self.request.user.groups.filter(name='administrator').exists()
 
     def form_valid(self, form):
         try:
@@ -1619,4 +1625,18 @@ class AdministratorAnnouncementCreateView(FormView):
         logger.error(f"Form errors: {form.errors}")
         messages.error(self.request, 'There was an error creating the announcement. Please check the form and try again.')
         return super().form_invalid(form)
+
+
+class AdministratorAnnouncementDetailView(LoginRequiredMixin, UserPassesTestMixin, DetailView):
+    model = Announcement
+    template_name = 'users/administrator/announcements/announcement_detail.html'
+    context_object_name = 'announcement'
+
+    def test_func(self):
+        return self.request.user.groups.filter(name='administrator').exists()
+
+    def get_object(self):
+        return get_object_or_404(Announcement, pk=self.kwargs.get('pk'))
+
+    
 

--- a/users/urls.py
+++ b/users/urls.py
@@ -96,7 +96,8 @@ urlpatterns = [
 
     # announcements
      path('administrator/announcements/', administrator_views.AdministratorAnnouncementListView.as_view(), name='administrator_announcement_list'),
-     path('administrator/announcement/create/', administrator_views.AdministratorAnnouncementCreateView.as_view(), name='administrator_announcement_create'),    
+     path('administrator/announcement/create/', administrator_views.AdministratorAnnouncementCreateView.as_view(), name='administrator_announcement_create'),
+     path('administrator/announcement/<uuid:pk>/detail/', administrator_views.AdministratorAnnouncementDetailView.as_view(), name='administrator_announcement_detail'),  
 
 
 


### PR DESCRIPTION
- Implemented AdministratorAnnouncementDetailView to display detailed information about an announcement.
- Added template 'announcement_detail.html' to show announcement details including title, priority, published date, expiry date, created at, updated at, and content.
- Restricted access to the detail view to logged-in users who are part of the 'administrator' group.
- Updated URL patterns to include the detail view with UUID support.