### PR TITLE
feat: Add support for deleting announcements and make 'Cancel' button…

### DIFF
--- a/templates/users/administrator/announcements/announcement_confirm_delete.html
+++ b/templates/users/administrator/announcements/announcement_confirm_delete.html
@@ -1,0 +1,23 @@
+{% extends '../_base.html' %}
+{% load static %}
+{% load i18n %}
+
+{% block title %}{% trans "Announcements - LMS Admin" %}{% endblock %}
+
+{% block extra_css %}
+{% endblock %}
+
+{% block content %}
+
+<div class="container mx-auto p-4">
+    <h1 class="text-2xl font-bold mb-4">{% trans "Delete Announcement" %}</h1>
+    <p>{% trans "Are you sure you want to delete this announcement?" %}</p>
+    <p><strong>{{ announcement.title }}</strong></p>
+    <form method="post">
+        {% csrf_token %}
+        <button type="submit" class="text-red-600 hover:text-red-900">{% trans "Confirm Delete" %}</button>
+        <a href="{% url 'administrator_announcement_list' %}" class="text-blue-500">{% trans "Cancel" %}</a>
+    </form>
+</div>
+
+{% endblock %}

--- a/templates/users/administrator/announcements/announcement_create.html
+++ b/templates/users/administrator/announcements/announcement_create.html
@@ -75,7 +75,7 @@
 
                     <div class="form-group">
                         <button type="submit" class="btn btn-primary">{% trans "Submit Announcement" %}</button>
-                        <a href="#" class="btn btn-secondary">{% trans "Cancel" %}</a>
+                        <a href="{% url 'administrator_announcement_list' %}" class="btn btn-secondary">{% trans "Cancel" %}</a>
                     </div>
                 </form>
             </div>

--- a/templates/users/administrator/announcements/announcements.html
+++ b/templates/users/administrator/announcements/announcements.html
@@ -140,9 +140,11 @@
                         <button class="text-green-600 hover:text-green-900 ml-3 rtl:mr-3 rtl:ml-0" title="{% trans 'View Statistics' %}">
                             <i class="fas fa-chart-bar"></i>
                         </button>
-                        <button class="text-red-600 hover:text-red-900 ml-3 rtl:mr-3 rtl:ml-0" title="{% trans 'Delete Announcement' %}">
-                            <i class="fas fa-trash"></i>
-                        </button>
+                        <a href="{% url 'administrator_announcement_delete' announcement.pk %}" title="{% trans 'Delete Announcement' %}">
+                            <button class="text-red-600 hover:text-red-900 ml-3 rtl:mr-3 rtl:ml-0">
+                                <i class="fas fa-trash"></i>
+                            </button>
+                        </a>
                     </td>
                 </tr>
                 {% endfor %}

--- a/users/administrator_views.py
+++ b/users/administrator_views.py
@@ -1639,4 +1639,14 @@ class AdministratorAnnouncementDetailView(LoginRequiredMixin, UserPassesTestMixi
         return get_object_or_404(Announcement, pk=self.kwargs.get('pk'))
 
     
+class AdministratorAnnouncementDeleteView(LoginRequiredMixin, UserPassesTestMixin,DeleteView):
+    model = Announcement
+    template_name = 'users/administrator/announcements/announcement_confirm_delete.html'
+    context_object_name = 'announcement'
+    success_url = reverse_lazy('administrator_announcement_list')
 
+    def test_func(self):
+        return self.request.user.groups.filter(name='administrator').exists()
+
+    def get_object(self):
+        return get_object_or_404(Announcement, pk=self.kwargs.get('pk'))

--- a/users/urls.py
+++ b/users/urls.py
@@ -97,7 +97,8 @@ urlpatterns = [
     # announcements
      path('administrator/announcements/', administrator_views.AdministratorAnnouncementListView.as_view(), name='administrator_announcement_list'),
      path('administrator/announcement/create/', administrator_views.AdministratorAnnouncementCreateView.as_view(), name='administrator_announcement_create'),
-     path('administrator/announcement/<uuid:pk>/detail/', administrator_views.AdministratorAnnouncementDetailView.as_view(), name='administrator_announcement_detail'),  
+     path('administrator/announcement/<uuid:pk>/detail/', administrator_views.AdministratorAnnouncementDetailView.as_view(), name='administrator_announcement_detail'),
+     path('administrator/announcement/<uuid:pk>/delete/', administrator_views.AdministratorAnnouncementDeleteView.as_view(), name='administrator_announcement_delete'),
 
 
 


### PR DESCRIPTION
… functional

- Implemented AdministratorAnnouncementDeleteView to handle the deletion of announcements.
- Added delete confirmation template 'announcement_confirm_delete.html'.
- Updated URL patterns to include the delete view with UUID support.
- Enhanced announcements list table to include a delete button with a trash icon.
- Made the 'Cancel' button functional in the 'Create Announcement' page to redirect back to the announcements list.