### PR TITLE
feat: Add update support for announcements

### DIFF
--- a/templates/users/administrator/announcements/announcement_update.html
+++ b/templates/users/administrator/announcements/announcement_update.html
@@ -1,0 +1,22 @@
+{% extends '../_base.html' %}
+{% load static %}
+{% load i18n %}
+
+{% block title %}{% trans "Announcements - LMS Admin" %}{% endblock %}
+
+{% block extra_css %}
+{% endblock %}
+
+{% block content %}
+
+<div class="container mx-auto p-4">
+    <h1 class="text-2xl font-bold mb-4">{% trans "Edit/Update Announcement" %}</h1>
+    <form method="post">
+        {% csrf_token %}
+        {{ form.as_p }}
+        <button type="submit" class="text-blue-600 hover:text-blue-900">{% trans "Save Changes" %}</button>
+        <a href="{% url 'administrator_announcement_list' %}" class="text-red-500">{% trans "Cancel" %}</a>
+    </form>
+</div>
+
+{% endblock %}

--- a/templates/users/administrator/announcements/announcements.html
+++ b/templates/users/administrator/announcements/announcements.html
@@ -137,9 +137,11 @@
                                 <i class="fas fa-eye"></i>
                             </button>
                         </a>
-                        <button class="text-green-600 hover:text-green-900 ml-3 rtl:mr-3 rtl:ml-0" title="{% trans 'View Statistics' %}">
-                            <i class="fas fa-chart-bar"></i>
-                        </button>
+                        <a href="{% url 'administrator_announcement_edit' announcement.pk %}" title="{% trans 'Edit/Update Announcement' %}">
+                            <button class="text-blue-600 hover:text-blue-900 ml-3 rtl:mr-3 rtl:ml-0">
+                                <i class="fas fa-edit"></i>
+                            </button>
+                        </a>
                         <a href="{% url 'administrator_announcement_delete' announcement.pk %}" title="{% trans 'Delete Announcement' %}">
                             <button class="text-red-600 hover:text-red-900 ml-3 rtl:mr-3 rtl:ml-0">
                                 <i class="fas fa-trash"></i>

--- a/users/administrator_views.py
+++ b/users/administrator_views.py
@@ -1650,3 +1650,17 @@ class AdministratorAnnouncementDeleteView(LoginRequiredMixin, UserPassesTestMixi
 
     def get_object(self):
         return get_object_or_404(Announcement, pk=self.kwargs.get('pk'))
+
+
+class AdministratorAnnouncementUpdateView(LoginRequiredMixin, UserPassesTestMixin,UpdateView):
+    model = Announcement
+    form_class = AnnouncementForm
+    template_name = 'users/administrator/announcements/announcement_update.html'
+    context_object_name = 'announcement'
+    success_url = reverse_lazy('administrator_announcement_list')
+
+    def test_func(self):
+        return self.request.user.groups.filter(name='administrator').exists()
+
+    def get_object(self):
+        return get_object_or_404(Announcement, pk=self.kwargs.get('pk'))

--- a/users/urls.py
+++ b/users/urls.py
@@ -99,6 +99,7 @@ urlpatterns = [
      path('administrator/announcement/create/', administrator_views.AdministratorAnnouncementCreateView.as_view(), name='administrator_announcement_create'),
      path('administrator/announcement/<uuid:pk>/detail/', administrator_views.AdministratorAnnouncementDetailView.as_view(), name='administrator_announcement_detail'),
      path('administrator/announcement/<uuid:pk>/delete/', administrator_views.AdministratorAnnouncementDeleteView.as_view(), name='administrator_announcement_delete'),
+     path('administrator/announcement/<uuid:pk>/edit/', administrator_views.AdministratorAnnouncementUpdateView.as_view(), name='administrator_announcement_edit'),
 
 
 


### PR DESCRIPTION
- Implemented AdministratorAnnouncementUpdateView to handle editing announcements.
- Added template 'announcement_form.html' for editing announcements.
- Updated URL patterns to include the edit view with UUID support.
- Enhanced announcements list table to include an edit button with an edit icon.
- Ensured the update feature is fully functional, allowing administrators to edit announcement details.